### PR TITLE
Fixed timeout issue previously thought to be an I2C bus freezing error.

### DIFF
--- a/HeadGamingMouse/GY521.cpp
+++ b/HeadGamingMouse/GY521.cpp
@@ -79,12 +79,12 @@ bool GY521::isConnected()
 {
   _wire->beginTransmission(_address);
   int response = _wire->endTransmission();
-  if (response == 5) {
-    Serial.print("Timed out");
-    Serial.println();
-  } else {
-    Serial.print(response);
-  }
+  //if (response == 5) {
+    //Serial.print("Timed out");
+    //Serial.println();
+  //} else {
+    //Serial.print(response);
+  //}
   return (response == 0);
 }
 

--- a/HeadGamingMouse/GY521.cpp
+++ b/HeadGamingMouse/GY521.cpp
@@ -44,6 +44,7 @@
 //
 GY521::GY521(uint8_t address, TwoWire *wire)
 {
+  Serial.begin( 115200 );
   _address = address;
   _wire    = wire;
   reset();
@@ -77,7 +78,14 @@ bool GY521::begin()
 bool GY521::isConnected()
 {
   _wire->beginTransmission(_address);
-  return (_wire->endTransmission() == 0);
+  int response = _wire->endTransmission();
+  if (response == 5) {
+    Serial.print("Timed out");
+    Serial.println();
+  } else {
+    Serial.print(response);
+  }
+  return (response == 0);
 }
 
 void GY521::reset()
@@ -318,4 +326,3 @@ int16_t GY521::_WireRead2()
 
 
 // -- END OF FILE --
-

--- a/HeadGamingMouse/HeadGamingMouse.cpp
+++ b/HeadGamingMouse/HeadGamingMouse.cpp
@@ -130,6 +130,7 @@ void HeadGamingMouse::demo_gamepad()
 
 void HeadGamingMouse::demo_imu()
 {
+    Serial.println("demo_imu()");
     if ( imu->isConnected() )
     {
         imu->read();
@@ -148,6 +149,7 @@ void HeadGamingMouse::demo_imu()
  */
 void HeadGamingMouse::process()
 {
+    //Serial.println("process()");
     cur_time = millis();
 
     // poll gyroscope within a certain time interval

--- a/HeadGamingMouse/HeadGamingMouse.cpp
+++ b/HeadGamingMouse/HeadGamingMouse.cpp
@@ -130,7 +130,7 @@ void HeadGamingMouse::demo_gamepad()
 
 void HeadGamingMouse::demo_imu()
 {
-    Serial.println("demo_imu()");
+    //Serial.println("demo_imu()");
     if ( imu->isConnected() )
     {
         imu->read();

--- a/HeadGamingMouse/HeadGamingMouse.ino
+++ b/HeadGamingMouse/HeadGamingMouse.ino
@@ -6,14 +6,14 @@ PicoGamepad gamepad;
 
 HeadGamingMouse *mouse;
 
-uint16_t cur_time;
-uint16_t last_gyro_time;
-uint16_t gyro_delay;
-uint16_t flag;
+uint64_t cur_time;
+uint64_t last_gyro_time;
+uint64_t gyro_delay;
+uint64_t flag;
 
 void setup()
 {
-  //Serial.begin( 115200 );
+  Serial.begin( 115200 );
   mouse = new HeadGamingMouse( &gamepad );
   //mouse = new HeadGamingMouse;
 
@@ -26,13 +26,11 @@ void loop()
 {
   mouse->process();
 
-  // cur_time = millis();
-  // if ( cur_time - last_gyro_time > gyro_delay )
-  // {
-  //   last_gyro_time = cur_time;
-  //   mouse->demo_imu();
-
-  // }
+  cur_time = millis();
+  if ( cur_time - last_gyro_time > gyro_delay )
+  {
+    last_gyro_time = cur_time;
+    mouse->demo_imu();
+  }
 
 }
-


### PR DESCRIPTION
The time variables used to space out gyro readings (cur_time, last_gyro_time, gyro_delay, flag) were set to uint16_t - equivalent to a short. Changing these to uint64_t (long) resolves the issue.